### PR TITLE
Fix streamlit src module import error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+# Asegura que el proyecto raíz esté en sys.path para poder importar el paquete 'src'
+project_root = Path(__file__).resolve().parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from src.app import main
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/app.py
+++ b/src/app.py
@@ -11,10 +11,10 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 from pathlib import Path
 
-# Agregar src al path para importaciones
-src_path = Path(__file__).parent
-if str(src_path) not in sys.path:
-    sys.path.insert(0, str(src_path))
+# Ajustar sys.path para que el paquete 'src' sea importable
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 # Configure logging
 logging.basicConfig(
@@ -25,16 +25,16 @@ logger = logging.getLogger(__name__)
 
 # Import application modules con manejo de errores
 try:
-    from core.wifi_extractor import WiFiProfileExtractor, WiFiProfile
-    from core.exceptions import (
+    from src.core.wifi_extractor import WiFiProfileExtractor, WiFiProfile
+    from src.core.exceptions import (
         UnsupportedOperatingSystemError,
         InsufficientPrivilegesError,
         NoWiFiProfilesFoundError,
         WiFiExtractorBaseException
     )
-    from utils.system_utils import SystemUtils, PrivilegeManager
-    from utils.data_utils import DataExporter, DataFilter, DataFormatter
-    from config.settings import app_config
+    from src.utils.system_utils import SystemUtils, PrivilegeManager
+    from src.utils.data_utils import DataExporter, DataFilter, DataFormatter
+    from src.config.settings import app_config
 except ImportError as e:
     st.error(f"Error importing modules: {e}")
     st.error("Please ensure all project files are in place")

--- a/src/utils/system_utils.py
+++ b/src/utils/system_utils.py
@@ -218,7 +218,7 @@ class PrivilegeManager:
             "is_admin": is_admin,
             "can_access_passwords": is_admin,
             "os_compatible": SystemUtils.is_windows(),
-            "recommendations": SystemUtils._get_privilege_recommendations(is_admin)
+            "recommendations": PrivilegeManager._get_privilege_recommendations(is_admin)
         }
     
     @staticmethod


### PR DESCRIPTION
Fix Streamlit deployment by resolving 'src' module import errors and providing a root entry point.

The original setup caused `No module named 'src'` because Python's `sys.path` didn't include the project root, preventing `src` from being recognized as a package. Additionally, Streamlit typically runs an app from the repository root, so a wrapper `app.py` was needed to correctly launch the main application logic located in `src/app.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f32b6ee2-87e1-4d1f-bd5d-038450e5c2a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f32b6ee2-87e1-4d1f-bd5d-038450e5c2a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

